### PR TITLE
Upgrade SixLabors.ImageSharp to 3.1.4

### DIFF
--- a/src/IRAAS.StressTest/IRAAS.StressTest.csproj
+++ b/src/IRAAS.StressTest/IRAAS.StressTest.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PeanutButter.EasyArgs" Version="3.0.276" />
+    <PackageReference Include="PeanutButter.EasyArgs" Version="3.0.306" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IRAAS.Tests/DiscoveryTests.cs
+++ b/src/IRAAS.Tests/DiscoveryTests.cs
@@ -52,7 +52,7 @@ namespace IRAAS.Tests
                 new JpegEncoder()
                 {
                     Quality = 85,
-                    ColorType = JpegColorType.YCbCrRatio420
+                    ColorType = JpegEncodingColor.YCbCrRatio420
                 });
             targetStream.Close();
             // Assert

--- a/src/IRAAS.Tests/IRAAS.Tests.csproj
+++ b/src/IRAAS.Tests/IRAAS.Tests.csproj
@@ -30,7 +30,7 @@
       <PackageReference Include="PeanutButter.SimpleTcpServer" Version="3.0.276" />
       <PackageReference Include="PeanutButter.Utils" Version="3.0.276" />
       <PackageReference Include="Quackers.TestLogger" Version="1.0.24" />
-      <PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IRAAS.Tests/IRAAS.Tests.csproj
+++ b/src/IRAAS.Tests/IRAAS.Tests.csproj
@@ -24,11 +24,11 @@
       <PackageReference Include="NSubstitute" Version="5.1.0" />
       <PackageReference Include="NUnit" Version="4.1.0" />
       <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-      <PackageReference Include="PeanutButter.JObjectExtensions" Version="3.0.276" />
-      <PackageReference Include="PeanutButter.RandomGenerators" Version="3.0.276" />
-      <PackageReference Include="PeanutButter.SimpleHTTPServer" Version="3.0.276" />
-      <PackageReference Include="PeanutButter.SimpleTcpServer" Version="3.0.276" />
-      <PackageReference Include="PeanutButter.Utils" Version="3.0.276" />
+      <PackageReference Include="PeanutButter.JObjectExtensions" Version="3.0.306" />
+      <PackageReference Include="PeanutButter.RandomGenerators" Version="3.0.306" />
+      <PackageReference Include="PeanutButter.SimpleHTTPServer" Version="3.0.306" />
+      <PackageReference Include="PeanutButter.SimpleTcpServer" Version="3.0.306" />
+      <PackageReference Include="PeanutButter.Utils" Version="3.0.306" />
       <PackageReference Include="Quackers.TestLogger" Version="1.0.24" />
       <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
     </ItemGroup>

--- a/src/IRAAS.Tests/ImageProcessing/TestImageResizeOptions.cs
+++ b/src/IRAAS.Tests/ImageProcessing/TestImageResizeOptions.cs
@@ -181,19 +181,19 @@ namespace IRAAS.Tests.ImageProcessing
                 // Arrange
                 var sut = Create();
                 // Act
-                Expect(sut.JpegColorType).To.Be.Null();
+                Expect(sut.JpegEncodingColor).To.Be.Null();
                 // Assert
             }
             [Test]
             public void ShouldBeSettable()
             {
                 // Arrange
-                var expected = GetRandom<JpegColorType>();
+                var expected = GetRandom<JpegEncodingColor>();
                 var sut = Create();
                 // Act
-                sut.JpegColorType = expected;
+                sut.JpegEncodingColor = expected;
                 // Assert
-                Expect(sut.JpegColorType).To.Equal(expected);
+                Expect(sut.JpegEncodingColor).To.Equal(expected);
             }
         }
 

--- a/src/IRAAS.Tests/ImageProcessing/TestUrlFetcher.cs
+++ b/src/IRAAS.Tests/ImageProcessing/TestUrlFetcher.cs
@@ -167,7 +167,7 @@ public class TestUrlFetcher
         server.AddHandler(
             (processor, _) =>
             {
-                if (processor.Path != "/cat.bmp")
+                if (processor.Path.TrimStart('/') != "cat.bmp")
                 {
                     return HttpServerPipelineResult.NotHandled;
                 }

--- a/src/IRAAS/IRAAS.csproj
+++ b/src/IRAAS/IRAAS.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
     <PackageReference Include="PeanutButter.DuckTyping" Version="3.0.276" />
     <PackageReference Include="PeanutButter.Utils" Version="3.0.276" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.2" />
   </ItemGroup>
 

--- a/src/IRAAS/IRAAS.csproj
+++ b/src/IRAAS/IRAAS.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="PeanutButter.DuckTyping" Version="3.0.276" />
-    <PackageReference Include="PeanutButter.Utils" Version="3.0.276" />
+    <PackageReference Include="PeanutButter.DuckTyping" Version="3.0.306" />
+    <PackageReference Include="PeanutButter.Utils" Version="3.0.306" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.2" />
   </ItemGroup>

--- a/src/IRAAS/ImageProcessing/ImageMimeTypeProvider.cs
+++ b/src/IRAAS/ImageProcessing/ImageMimeTypeProvider.cs
@@ -24,7 +24,17 @@ namespace IRAAS.ImageProcessing
                 throw new ArgumentNullException(nameof(imageStream));
             }
 
-            var format = Image.DetectFormat(imageStream);
+            IImageFormat format = null;
+            try
+            {
+                format = Image.DetectFormat(imageStream);
+            }
+            catch (UnknownImageFormatException)
+            {
+                // suppress - DetectFormat used to return
+                // null, now it throws on error
+            }
+
             if (format == null)
             {
                 throw new NotSupportedException(

--- a/src/IRAAS/ImageProcessing/ImageResizeOptions.cs
+++ b/src/IRAAS/ImageProcessing/ImageResizeOptions.cs
@@ -109,7 +109,15 @@ namespace IRAAS.ImageProcessing
         private int? _height;
 
         public ResizeMode? ResizeMode { get; set; }
-        public JpegColorType? JpegColorType { get; set; }
+
+        [Obsolete("JpegColorType was renamed upstream to JpegEncodingColor")]
+        public JpegEncodingColor? JpegColorType
+        {
+            get => JpegEncodingColor;
+            set => JpegEncodingColor = value;
+        }
+
+        public JpegEncodingColor? JpegEncodingColor { get; set; }
 
         [Min(0)]
         [Max(1)]

--- a/src/IRAAS/ImageProcessing/ImageResizer.cs
+++ b/src/IRAAS/ImageProcessing/ImageResizer.cs
@@ -8,6 +8,7 @@ using IRAAS.Security;
 using PeanutButter.Utils;
 using PeanutButter.Utils.Dictionaries;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.Formats.Jpeg;
@@ -54,10 +55,20 @@ namespace IRAAS.ImageProcessing
                 TimingHeaders.Fetch,
                 () => _fetcher.Fetch(options.Url, requestHeaders
                 ));
-            var sourceFormat = timer.Time(
-                TimingHeaders.SourceFormatDetection,
-                () => Image.DetectFormat(src.Stream)
-            );
+            IImageFormat sourceFormat = null;
+            try
+            {
+                sourceFormat = timer.Time(
+                    TimingHeaders.SourceFormatDetection,
+                    () => Image.DetectFormat(src.Stream)
+                );
+            }
+            catch (UnknownImageFormatException)
+            {
+                // suppress - previously, ImageSharp would
+                // simply return null from DetectFormat
+            }
+
             if (sourceFormat == null)
             {
                 throw new NotSupportedException(
@@ -302,7 +313,7 @@ namespace IRAAS.ImageProcessing
                 new JpegEncoder()
                 {
                     Quality = options.Quality,
-                    ColorType = options.JpegColorType
+                    ColorType = options.JpegEncodingColor
                 });
         }
 


### PR DESCRIPTION
Now that IRAAS is open-source, we can upgrade to the latest ImageSharp, which has a dual-license